### PR TITLE
Retrive last session key

### DIFF
--- a/src/client/server.spec.ts
+++ b/src/client/server.spec.ts
@@ -23,11 +23,12 @@ describe('makePohttpClient', () => {
     });
   });
 
-  describe('GET', () => {
+  describe('GET 2', () => {
     test('test get last session key', async () => {
       const response = await server.inject({ method: 'GET', url: '/testsessionkey' });
 
-      expect(response.statusCode).toBe(HTTP_STATUS_CODES.OK);
+      const json = response.json();
+      expect(json.recipientSessionKey).not.toBe(null);
     });
   });
 
@@ -59,5 +60,3 @@ describe('makePohttpClient', () => {
     });
   });
 });
-
-

--- a/src/client/server.spec.ts
+++ b/src/client/server.spec.ts
@@ -7,7 +7,6 @@ import { CE_ID, CE_SOURCE } from '../testUtils/eventing/stubs.js';
 import { postEvent } from '../testUtils/eventing/cloudEvents.js';
 
 import { PohttpClientProblemType } from './PohttpClientProblemType.js';
-
 describe('makePohttpClient', () => {
   const getTestServerFixture = setUpTestPohttpClient();
   let server: FastifyInstance;
@@ -21,6 +20,14 @@ describe('makePohttpClient', () => {
 
       expect(response.statusCode).toBe(HTTP_STATUS_CODES.OK);
       expect(response.body).toBe('It works');
+    });
+  });
+
+  describe('GET', () => {
+    test('test get last session key', async () => {
+      const response = await server.inject({ method: 'GET', url: '/testsessionkey' });
+
+      expect(response.statusCode).toBe(HTTP_STATUS_CODES.OK);
     });
   });
 
@@ -52,3 +59,5 @@ describe('makePohttpClient', () => {
     });
   });
 });
+
+

--- a/src/utilities/awala/InternetEndpoint.ts
+++ b/src/utilities/awala/InternetEndpoint.ts
@@ -76,7 +76,7 @@ export class InternetEndpoint extends Endpoint {
   public async saveChannel(
     connectionParams: PrivateEndpointConnParams,
     dbConnection: Connection,
-  ): Promise<void> {
+  ): Promise<InternetPrivateEndpointChannel> {
     const channel = await this.savePrivateEndpointChannel(connectionParams);
     const peerId = channel.peer.id;
     const { internetGatewayAddress } = connectionParams;
@@ -96,6 +96,8 @@ export class InternetEndpoint extends Endpoint {
         upsert: true,
       },
     );
+
+    return channel;
   }
 
   protected async retrieveInitialSessionKeyId(): Promise<Buffer | null> {


### PR DESCRIPTION
I removed all the unnecessary code. routes tests 
The important part here is https://github.com/relaycorp/awala-endpoint-internet/pull/49/files#diff-42c5b9da7d8a329f54e6ffce5833cb544b3a3accb467a19132bbe8f23c19baf7R28-R48

It should return the session key but it returns null and this is the reason `channel.makeMessage` throws an error