### PR TITLE
feat: Improve logging

### DIFF
--- a/src/client/server.spec.ts
+++ b/src/client/server.spec.ts
@@ -296,7 +296,11 @@ describe('makePohttpClient', () => {
 
       const response = await postEvent(cloudEvent, server);
 
-      expect(logs).toContainEqual(partialPinoLog('warn', 'Could not find channel with peer'));
+      expect(logs).toContainEqual(
+        partialPinoLog('warn', 'Could not find channel with peer', {
+          peerId: cloudEventData.subject,
+        }),
+      );
       expect(response.statusCode).toBe(HTTP_STATUS_CODES.SERVICE_UNAVAILABLE);
     });
 

--- a/src/client/server.ts
+++ b/src/client/server.ts
@@ -83,6 +83,7 @@ export async function makePohttpClientPlugin(server: FastifyInstance): Promise<v
 
     const parcelAwareLogger = request.log.child({
       parcelId: event.id,
+      peerId: event.subject,
     });
     const messageOptions = getOutgoingServiceMessageOptions(event, parcelAwareLogger);
     if (!messageOptions) {


### PR DESCRIPTION
- Some logs weren't aware of the current request.
- Normalised field to refer to the peer id (`peerId, but sometimes it was `senderId`).
- Include `peerId` everywhere.