### PR TITLE
fix: Revert "fix: Really only log "Parcel delivered" when it's actually true"

### DIFF
--- a/src/client/server.spec.ts
+++ b/src/client/server.spec.ts
@@ -336,7 +336,7 @@ describe('makePohttpClient', () => {
             internetGatewayAddress: PEER_ADDRESS,
           }),
         );
-        expect(logs).not.toContainEqual(parcelDeliveryLog);
+        expect(logs).toContainEqual(parcelDeliveryLog);
         expect(response.statusCode).toBe(HTTP_STATUS_CODES.NO_CONTENT);
       });
 
@@ -357,7 +357,6 @@ describe('makePohttpClient', () => {
             internetGatewayAddress: PEER_ADDRESS,
           }),
         );
-        expect(logs).not.toContainEqual(parcelDeliveryLog);
         expect(response.statusCode).toBe(HTTP_STATUS_CODES.NO_CONTENT);
       });
 

--- a/src/client/server.ts
+++ b/src/client/server.ts
@@ -43,8 +43,9 @@ async function deliverParcelAndHandleErrors(
 ): Promise<boolean> {
   const gatewayAwareLogger = logger.child({ internetGatewayAddress: internetAddress });
   try {
-    await deliverParcel(internetAddress, parcelSerialised, { useTls: shouldUseTls });
-    gatewayAwareLogger.info('Parcel delivered');
+    await deliverParcel(internetAddress, parcelSerialised, {
+      useTls: shouldUseTls,
+    });
   } catch (err) {
     if (err instanceof PoHTTPInvalidParcelError) {
       gatewayAwareLogger.info({ err }, 'Gateway refused parcel as invalid');
@@ -115,7 +116,9 @@ export async function makePohttpClientPlugin(server: FastifyInstance): Promise<v
       shouldUseTls,
       parcelAwareLogger,
     );
+
     if (wasFulfilled) {
+      parcelAwareLogger.info('Parcel delivered');
       return reply.status(HTTP_STATUS_CODES.NO_CONTENT).send();
     }
 


### PR DESCRIPTION
This reverts commit 2dfa0f9dd26252db99cc0bc2f2fdbd42377c26f5.

... Because for some reason it's causing Skaffold in CI to time out. 🤷🏾 