### PR TITLE
fix: Run scripts directly (without `npm exec`)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@ WORKDIR /tmp/awala-endpoint
 COPY package*.json ./
 RUN npm install
 COPY . ./
-RUN npm run build && npm prune --omit=dev && rm -r src
+RUN npm run build && npm prune --omit=dev && rm -r src tsconfig.json
 
 FROM node:18.14.0-slim
 LABEL org.opencontainers.image.source="https://github.com/relaycorp/awala-endpoint-internet"
-USER node
+EXPOSE 8080
 WORKDIR /opt/awala-endpoint
-COPY --chown=node:node --from=build /tmp/awala-endpoint ./
 ENV NODE_ENV=production \
     NPM_CONFIG_UPDATE_NOTIFIER=false \
     NODE_OPTIONS="--unhandled-rejections=strict --experimental-vm-modules --enable-source-maps"
-ENTRYPOINT ["npm", "exec", "--offline", "--loglevel=warn"]
-EXPOSE 8080
+COPY --chown=node:node --from=build /tmp/awala-endpoint ./
+RUN npm link --save=false --fund=false
+USER node


### PR DESCRIPTION
So that signals can be handled correctly.
